### PR TITLE
remove sonar check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,20 +129,4 @@ jobs:
         with:
           name: coverage-report
           path: cover.out
-  sonarcloud:
-   if: github.event.pull_request.draft == false
-   name: SonarCloud
-   needs: test
-   runs-on: ubuntu-latest
-   steps:
-     - uses: actions/checkout@v5
-       with:
-         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-     - uses: actions/download-artifact@v5
-       with:
-         name: coverage-report
-     - name: SonarCloud Scan
-       uses: SonarSource/sonarqube-scan-action@v6
-       env:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+


### PR DESCRIPTION
Este pull request desativa o job de análise do SonarCloud do nosso pipeline de CI no GitHub Actions.

Resumo
O job sonarcloud, que era responsável pela análise estática de código e pelo relatório de cobertura, foi completamente removido do arquivo de configuração .github/workflows/test.yml. Com isso, os pull requests não serão mais analisados por esta ferramenta.

Contexto
Estamos descontinuando o uso do SonarCloud como parte de uma iniciativa para consolidar nossas ferramentas de análise estática. Esta funcionalidade agora é coberta pelo  Snyk Code e CodeQL, que oferece um feedback mais integrado e eficiente ao nosso fluxo de trabalho. A mudança simplifica nosso pipeline de CI e reduz a sobrecarga de manutenção.

Alterações Implementadas
Remoção completa do job sonarcloud do workflow de CI (.github/workflows/test.yml).

Remoção de todos os steps associados, incluindo o checkout de código, download de artefatos e a execução da action sonarsource/sonarcloud-github-action.

Próximos Passos
Após o merge deste PR, o secret SONAR_TOKEN poderá ser removido com segurança das configurações do repositório.